### PR TITLE
fix: remove conflicting javascript for mobile menu

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -57,20 +57,4 @@ $(document).ready(function () {
     trigger: "hover",
   });
 
-  // Simple navbar toggle
-  console.log('Setting up navbar toggle...');
-  
-  $(document).on('click', '.navbar-toggler', function(e) {
-    e.preventDefault();
-    console.log('Navbar toggle clicked!');
-    
-    var $menu = $('#navbarNav');
-    console.log('Menu element found:', $menu.length);
-    
-    $menu.toggleClass('show');
-    console.log('Menu classes after toggle:', $menu.attr('class'));
-    
-    // Toggle button state
-    $(this).toggleClass('collapsed');
-  });
 });


### PR DESCRIPTION
The mobile dropdown menu was not working due to a custom JavaScript implementation that conflicted with Bootstrap's native collapse functionality. This commit removes the custom JavaScript, allowing the Bootstrap default behavior to correctly handle the mobile menu.